### PR TITLE
Wrapped strings with new "santizer" function available in package.

### DIFF
--- a/post.go
+++ b/post.go
@@ -152,9 +152,9 @@ ON CONFLICT (id) DO UPDATE
 SET (title, content, date, draft, modified_at) = ($2, $3, $4, $5, $7)
 WHERE posts.id = $1;
 `,
-		p.ID,
-		p.Title,
-		p.Content,
+		sanitize(p.ID),
+		sanitize(p.Title),
+		sanitize(p.Content),
 		p.Datetime,
 		p.Draft,
 		p.Created,

--- a/resolver.go
+++ b/resolver.go
@@ -130,7 +130,7 @@ func (r *queryResolver) Posts(ctx context.Context, limit *int, offset *int) ([]*
 
 func (r *queryResolver) Post(ctx context.Context, id string) (*Post, error) {
 	var post Post
-	row := db.QueryRowContext(ctx, "SELECT id, title, content, date, created_at, modified_at, tags, draft FROM posts WHERE id = $1", id)
+	row := db.QueryRowContext(ctx, "SELECT id, title, content, date, created_at, modified_at, tags, draft FROM posts WHERE id = $1", sanitize(id))
 	err := row.Scan(&post.ID, &post.Title, &post.Content, &post.Datetime, &post.Created, &post.Modified, pq.Array(&post.Tags), &post.Draft)
 	switch {
 	case err == sql.ErrNoRows:

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -1,0 +1,13 @@
+package graphql
+
+import (
+	"fmt"
+	"strings"
+)
+
+// sanitize will replace existing backticks with escape chars, then wrap in backticks.
+func sanitize(str string) string {
+	withEscapedBackticks := strings.Replace(str, "`", "\\`", -1)
+	wrappedSanitizedString := fmt.Sprintf("`%s`", withEscapedBackticks)
+	return wrappedSanitizedString;
+}

--- a/user.go
+++ b/user.go
@@ -24,8 +24,8 @@ func (u *User) Save(ctx context.Context) error {
     ON CONFLICT (id) DO UPDATE
     SET (role, modified_at) = ($2, $4)
     WHERE users.id = $1;`,
-		u.ID,
-		u.Role,
+		sanitize(u.ID),
+		sanitize(u.Role),
 		u.Created,
 		time.Now())
 
@@ -36,6 +36,7 @@ func (u *User) Save(ctx context.Context) error {
 // create it.
 func GetUser(ctx context.Context, id string) (*User, error) {
 	var user User
+	id = sanitize(id);
 	row := db.QueryRowContext(ctx, "SELECT id, role, created_at, modified_at FROM users WHERE id = $1", id)
 	err := row.Scan(&user.ID, &user.Role, &user.Created, &user.Modified)
 


### PR DESCRIPTION
It was easy enough to do string.Replace for any existing backticks in the string, then wrap times it's called into the db *with a string*. I've left examples here, so let me know if you have any issues!